### PR TITLE
Use CARGO_BUILD_WARNINGS in CI recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -78,16 +78,17 @@ ci-check:
     just check-all
 
 # CI: clippy warnings are treated as errors.
+[env("CARGO_BUILD_WARNINGS", "deny")]
 ci-clippy:
-    just clippy-all -- -D warnings
+    just clippy-all
 
 # CI: rustdoc warnings are treated as errors.
-[env("RUSTDOCFLAGS", x'${RUSTDOCFLAGS:-} -D warnings')]
+[env("CARGO_BUILD_WARNINGS", "deny")]
 ci-rustdoc:
     just doc-all --no-deps
 
 # CI: docs.rs warnings are treated as errors.
-[env("RUSTDOCFLAGS", x'${RUSTDOCFLAGS:-} -D warnings')]
+[env("CARGO_BUILD_WARNINGS", "deny")]
 ci-docs-rs:
     just docs-rs-all
 


### PR DESCRIPTION
## Summary
- replace `-D warnings` clippy invocations with `CARGO_BUILD_WARNINGS=deny`
- replace rustdoc warning handling via `RUSTDOCFLAGS` with `CARGO_BUILD_WARNINGS=deny`
- update template justfiles where applicable

## Note
- Cargo 1.97 stabilized `build.warnings` / `CARGO_BUILD_WARNINGS`, and this also makes Clippy and rustdoc lint warnings for local packages fail under `cargo clippy` and `cargo doc --no-deps`, so the explicit `-- -D warnings` and `RUSTDOCFLAGS=-D warnings` are no longer needed here.
