### PR TITLE
Use cargo hack toolchain flag for sync-rdme

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,7 +60,7 @@ docs-rs-all *args:
 
 # Synchronize README snippets for all packages.
 sync-rdme-all *args:
-    rustup run nightly cargo hack sync-rdme --workspace {{ args }}
+    cargo hack sync-rdme --toolchain nightly --workspace {{ args }}
 
 # Detect unused dependencies.
 machete *args:


### PR DESCRIPTION
## Summary
- replace `rustup run nightly cargo hack sync-rdme` with `cargo hack sync-rdme --toolchain nightly`
- keep the existing workspace invocation and arguments intact
